### PR TITLE
Show full review message

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -89,6 +89,16 @@ a.material-icons {
    position: relative;
    height: calc(100vh - 56px);
 }
+#container-handin .mdc-list-item {
+	min-height: 48px;
+	height: auto;
+	line-height: normal;
+	align-items: flex-start;
+}
+#container-handin .mdc-list-item .mdc-list-item__graphic {
+	padding-top: 8px;
+	padding-bottom: 8px;
+}
 #handin-upload,
 #handin-review {
    border: 1px dashed #e6e6e6;


### PR DESCRIPTION
Now showing the full review message in a handin. Long messages were cutoff because the container wasn't growing in height. Line-height is now set to normal and is aligned with the top-left corner of its container.

![image](https://user-images.githubusercontent.com/10333951/94945309-c5a15b80-04da-11eb-8d0e-689e02a4006d.png)

![image](https://user-images.githubusercontent.com/10333951/94945259-b7533f80-04da-11eb-9fce-2dd29a9c0858.png)